### PR TITLE
IPv6 edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ set role to `aoscx-ansible-role`:
             interface: 1/1/3
             description: Uplink_Interface
             ipv4: ['10.20.1.3/24']
-            ipv6: ['2000:db8::1234/32']
+            ipv6: ['2001:db8::1234/64']
 ```
 
 If role installed through [Galaxy](https://galaxy.ansible.com/arubanetworks/aoscx)
@@ -86,7 +86,7 @@ set role to `arubanetworks.aoscx`:
             interface: 1/1/3
             description: Uplink_Interface
             ipv4: ['10.20.1.3/24']
-            ipv6: ['2000:db8::1234/32']
+            ipv6: ['2001:db8::1234/64']
 ```
 
 Contribution

--- a/library/aoscx_acl.py
+++ b/library/aoscx_acl.py
@@ -67,16 +67,16 @@ EXAMPLES = r'''
             }
       }
 
-- name: Configure IPv6 ACL with entry - 809 permit icmpv6 1000:1012:1cce:820b::12 1000:1012:1cce:820b::12
+- name: Configure IPv6 ACL with entry - 809 permit icmpv6 2001:db8::11 2001:db8::12
   aoscx_acl:
     name: ipv6_acl_example
     type: ipv6
     acl_entries: {
       '809': {action: permit, # ACL Entry Action - choices: ['permit', 'deny']
               count: false, # Enable 'count' on the ACL Entry - choices: ['permit', 'deny']
-              dst_ip: 1000:1012:1cce:820b::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff,  # Matching Destination IPv6 address, format IP/MASK
+              dst_ip: 2001:db8::11/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff,  # Matching Destination IPv6 address, format IP/MASK
               protocol: icmpv6,  # Matching protocol
-              src_ip: 1000:1012:1cce:820b::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff # Matching Source IPv6 address, format IP/MASK
+              src_ip: 2001:db8::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff # Matching Source IPv6 address, format IP/MASK
               }
       }
 

--- a/library/aoscx_acl.py
+++ b/library/aoscx_acl.py
@@ -74,9 +74,9 @@ EXAMPLES = r'''
     acl_entries: {
       '809': {action: permit, # ACL Entry Action - choices: ['permit', 'deny']
               count: false, # Enable 'count' on the ACL Entry - choices: ['permit', 'deny']
-              dst_ip: 1000:1012:1cce:820b::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff,  # Matching Destination IPv4 address, format IP/MASK
+              dst_ip: 1000:1012:1cce:820b::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff,  # Matching Destination IPv6 address, format IP/MASK
               protocol: icmpv6,  # Matching protocol
-              src_ip: 1000:1012:1cce:820b::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff # Matching Source IPv4 address, format IP/MASK
+              src_ip: 1000:1012:1cce:820b::12/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff # Matching Source IPv6 address, format IP/MASK
               }
       }
 

--- a/library/aoscx_l3_interface.py
+++ b/library/aoscx_l3_interface.py
@@ -99,7 +99,7 @@ EXAMPLES = '''
     interface: 1/1/3
     description: Uplink Interface
     ipv4: ['10.20.1.3/24']
-    ipv6: ['2000:db8::1234/32']
+    ipv6: ['2000:db8::1234/64']
     vrf: red
 
 - name: Creating new L3 interface 1/1/6 with IPv4 address on VRF default


### PR DESCRIPTION
1. Altered README to RFC3849 2001:db8:: addresses rather than 2000::
2. Replaced /32 with /64, also in README.
3. Corrected typo in aoscx_acl.py - should be IPv6 not IPv4.
4. Also in aoscx_acl.py, created two RFC3849 addresses rather than the same address twice as in the original.