### PR TITLE
VLAN Native tagged check

### DIFF
--- a/library/aoscx_l2_interface.py
+++ b/library/aoscx_l2_interface.py
@@ -229,6 +229,11 @@ def main():
                     aruba_ansible_module.module.fail_json(
                         msg="VLAN {} is not configured".format(
                             params['native_vlan_id']))
+
+            elif  params['native_vlan_tag']:
+                  interface_vlan_dict['vlan_mode'] = 'native-tagged'
+                  interface_vlan_dict['vlan_tag'] = '1'
+                                               
             else:
                 interface_vlan_dict['vlan_mode'] = 'native-untagged'
                 interface_vlan_dict['vlan_tag'] = '1'

--- a/library/aoscx_l2_interface.py
+++ b/library/aoscx_l2_interface.py
@@ -216,8 +216,11 @@ def main():
 
             if params['native_vlan_id']:
                 if params['native_vlan_id'] == '1':
-                    interface_vlan_dict['vlan_mode'] = 'native-untagged'
                     interface_vlan_dict['vlan_tag'] = '1'
+                    if params['native_vlan_tag']:
+                        interface_vlan_dict['vlan_mode'] = 'native-tagged'
+                    else:
+                        interface_vlan_dict['vlan_mode'] = 'native-untagged'
                 elif vlan.check_vlan_exist(aruba_ansible_module,
                                          params['native_vlan_id']):
                     if params['native_vlan_tag']:


### PR DESCRIPTION
1. Additional check when native VLAN 1 is set. Previously this always resulted in native vlan untagged. Line 220-223 is an additional if statement to check native_vlan_tag.
2. Line 236 - 238 is to allow a default posture whereby native_vlan_tag is True but no native_vlan_id is set. This defaults to native VLAN 1 tagged. N.B. With the CLI it is not possible to have a state in which the native vlan is set to tagged but no native vlan for the port is set. The tagged keyword follows the vlan trunk command:  vlan trunk native 1 tag 

Tested with 8320 running TL.10.03.0040